### PR TITLE
Trim overrides

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -13,7 +13,9 @@ AltTexture{ -- Luna Seals
     path = 'lunas.png', -- path of sprites
     loc_txt = { -- localized name (this isn't used anywhere currently)
         name = 'Luna\'s Seals'
-    }
+    },
+    keys = {'Gold','Blue','Purple'},
+    original_sheet = true
 }
 AltTexture{ -- Luna Decks
     key = 'deck', -- alt_tex key
@@ -21,7 +23,9 @@ AltTexture{ -- Luna Decks
     path = 'lunas.png', -- path of sprites
     loc_txt = { -- localized name (this isn't used anywhere currently)
         name = 'Luna\'s Decks'
-    }
+    },
+    keys = {'b_blue','b_yellow','b_green','b_black'},
+    original_sheet = true
 }
 AltTexture({ -- Lunas Enhancements
     key = 'enhancements', -- alt_tex key


### PR DESCRIPTION
The original mod only makes changes to 3 seals and 4 decks, but this pack treats all decks and seals as being overwritten. This PR trims which seals and decks are affected by this pack to only the following:
- Gold Seal
- Blue Seal
- Purple Seal
- Blue Deck
- Yellow Deck
- Green Deck
- Black Deck